### PR TITLE
Funkcijų return iškvietimo realiazcija. Funkcijų operatorių overloadinimas.

### DIFF
--- a/samples/test.glang
+++ b/samples/test.glang
@@ -1,5 +1,7 @@
-fun int testas (int rez, <) {
-    print(5);
+fun void testas () {
+    if(5 != 5){
+        print(4 + 3);
+    }
+    print(4 + 3);
 }
-int a = 5;
-testas(a, ==);
+testas(+ -, != ==)

--- a/src/main/antlr4/edu/ktu/glang/GLang.g4
+++ b/src/main/antlr4/edu/ktu/glang/GLang.g4
@@ -10,17 +10,18 @@ line
 statement
     : variableDeclaration ';'
     | assignment ';'
-    | functionCall ';'
+    | functionCall
     | ifStatement
     | printStatement ';'
-    ;
+    | returnStatement ';' ;
 
-functionDeclaration : 'fun' TYPE ID '(' paramList? ')' functionBody ;
+
+functionDeclaration : 'fun' (TYPE | VOID) ID '(' paramList? ')' functionBody ;
 
 //paramList : TYPE ID (',' TYPE ID)* ;
 paramList: param (',' param)* ;
 
-param : typeParam | operator;
+param : typeParam;
 
 typeParam : TYPE ID ;
 
@@ -37,6 +38,7 @@ expression
     | '(' expression ')'                #parenthesesExpression
     | expression intMultiOp expression  #intMultiOpExpression
     | expression intAddOp expression    #intAddOpExpression
+    | functionCall                      #functionExpression
     ;
 
 intMultiOp : '*' | '/' | '%' ;
@@ -48,20 +50,18 @@ ifStatement : 'if' '(' expression relationOp expression ')' block ('else' block 
 functionCall : ID '(' argumentsList? ')' ;
 
 argumentsList
-: argument (',' argument)*
+: (expression | operatorOverload) (',' (expression | operatorOverload))*
 ;
 
-argument : expression | operator;
+operatorOverload : (relationOp relationOp) | (arithmeticOp arithmeticOp) ;
 
 block : '{' statement* '}' ;
 
 returnStatement : 'return' expression? ;
 
-
 relationOp : '==' | '!=' | '>' | '<' | '<=' | '>=';
 
-operator : '==' | '!=' | '>' | '<' | '<=' | '>=' |
-    '*' | '/' | '%' | '+' | '-';
+arithmeticOp : '+' | '-' | '*' | '/' | '%' ;
 
 printStatement : PRINT '(' expression ')' ;
 
@@ -70,6 +70,7 @@ TYPE    : 'int'
         | 'string'
         ;
 
+VOID : 'void' ;
 PRINT   : 'print';
 ID      : [a-zA-Z]+ ;
 INT     : [0-9]+ ;

--- a/src/main/java/edu/ktu/glang/interpreter/IfStatementVisitor.java
+++ b/src/main/java/edu/ktu/glang/interpreter/IfStatementVisitor.java
@@ -20,10 +20,9 @@ public class IfStatementVisitor extends GLangBaseVisitor<Object> {
 
         // Get the relation operator from the context
         TerminalNode relOpNode = (TerminalNode) ctx.relationOp().getChild(0);
-        String relOp = relOpNode.getText();
-
+        String operator = parent.getOperatorOverload(relOpNode.getText());
         // Resolve the condition and execute the appropriate statement
-        if (resolveCondition(left, right, relOp)) {
+        if (resolveCondition(left, right, operator)) {
             return parent.visit(ctx.block(0));
         } else if (ctx.block(1) != null) {
             return parent.visit(ctx.block(1));

--- a/src/main/java/edu/ktu/glang/interpreter/MVPLangScope.java
+++ b/src/main/java/edu/ktu/glang/interpreter/MVPLangScope.java
@@ -20,12 +20,12 @@ public class MVPLangScope {
 
     public void declareVariable(String variableName, Value value){
         if(isDeclared(variableName)){
-            throw new RuntimeException("Variable is already declared");
+            throw new RuntimeException(String.format("Variable '%s' is already declared.", variableName));
         }
         symbols.put(variableName, value);
     }
 
-    private boolean isDeclared(String variableName){
+    public boolean isDeclared(String variableName){
         if(symbols.containsKey(variableName)){
             return true;
         }
@@ -63,7 +63,7 @@ public class MVPLangScope {
         if(operatorOverload.containsKey(operator)){
             return true;
         }
-        return parent != null && parent.operatorOverload.containsKey(operator);
+        return parent != null && parent.isOverloaded(operator);
     }
 
     public void overLoadOperator(String operator, String newOperator){
@@ -72,7 +72,7 @@ public class MVPLangScope {
 
     public String resolveOperator(String operator){
         if (!isOverloaded(operator)) {
-            throw new RuntimeException("Operator not overloaded");
+            return null;
         }
         if (operatorOverload.containsKey(operator)) {
             return operatorOverload.get(operator);

--- a/src/main/java/edu/ktu/glang/interpreter/exception/MVPReturnStatementException.java
+++ b/src/main/java/edu/ktu/glang/interpreter/exception/MVPReturnStatementException.java
@@ -1,0 +1,9 @@
+package edu.ktu.glang.interpreter.exception;
+
+public class MVPReturnStatementException extends RuntimeException{
+    public Object object;
+    public MVPReturnStatementException(Object oobject){
+        super(String.format("Return was called."));
+        this.object = oobject;
+    }
+}

--- a/src/main/java/edu/ktu/glang/interpreter/types/Type.java
+++ b/src/main/java/edu/ktu/glang/interpreter/types/Type.java
@@ -31,4 +31,15 @@ public abstract class Type {
                 throw new RuntimeException("Unknown type");
         }
     }
+
+    public static Object castObjectToType(Object obj, String typeName){
+        switch(typeName){
+            case "int":
+                return (Integer)obj;
+            case "string":
+                return (String)obj;
+            default:
+                throw new RuntimeException("Unknown type");
+        }
+    }
 }

--- a/src/test/java/edu/ktu/glang/interpreter/ScopeTest.java
+++ b/src/test/java/edu/ktu/glang/interpreter/ScopeTest.java
@@ -41,7 +41,7 @@ public class ScopeTest {
     void variable_out_of_function_scope(){
         String program = """
                         int a = 5;
-                        fun int testas () {
+                        fun void testas () {
                         print(a);
                         }
                         testas();
@@ -56,11 +56,42 @@ public class ScopeTest {
     @Test
     void variable_only_in_function_scope(){
         String program = """
-                        fun int testas () {
+                        fun void testas () {
                         int a = 5;
                         }
                         testas();
                         print(a);
+                         """;
+
+        assertThrows(RuntimeException.class,
+                () -> {
+                    GLangInterpreter.execute(program);
+                });
+    }
+
+    @Test
+    void return_in_function(){
+        String program = """
+                        fun void testas () {
+                        print(5);
+                        return;
+                        print(6);
+                        }
+                        testas()
+                         """;
+
+        String expected = """
+                          5
+                          """;
+
+        String actual = GLangInterpreter.execute(program);
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void return_in_main_program(){
+        String program = """
+                        return 5;
                          """;
 
         assertThrows(RuntimeException.class,


### PR DESCRIPTION
Funkcijos gali iškviesti return. Jeigu funkcija turi grąžinti ne void, o kažkokį tipą, yra tikrinama ar return kvietimo argumento tipas sutampa su funkcijos reikalaujamu tipu. Return galima iškviesti bet kuriuo funkcijos metu ir jos veikimas bus nutrauktas. Realizuotas funkcijos operatorių overloadinimas. Kviečiant funkciją, galima nurodyti kokį ir į kokį operatorius overloadint. Šis argumentas gali būti bet kurioje funkcijos kvietimo vietoje, nes funkcijos reikalaujami argumentai yra tikrinami atskirai. Funkcijos deklaracijoj nurodyti operatoriaus, kad jį overloadint, nereikia. Dėl daugiau pavyzdžių, žiūrėti Unit testus "test" foldery.